### PR TITLE
Fix sample app to send custom event.

### DIFF
--- a/sample-apps/src/main/java/com/appdynamics/iotapps/MyIoTSampleApp.java
+++ b/sample-apps/src/main/java/com/appdynamics/iotapps/MyIoTSampleApp.java
@@ -30,6 +30,9 @@ public class MyIoTSampleApp {
     public static final String APP_KEY = "<YOUR-APP-KEY>";
     public static final String COLLECTOR_URL = "<YOUR-COLLECTOR-URL>";
 
+    //Simulates a long running application
+    private static final int LOOP_COUNT = 1;
+
     static final Logger LOGGER = LoggerFactory.getLogger(MyIoTSampleApp.class);
     private static MyAppKeyStateChangeListener listener = new MyAppKeyStateChangeListener() {};
 
@@ -37,9 +40,9 @@ public class MyIoTSampleApp {
         LOGGER.info("Initializing AppDynamics Instrumentation");
         initInstrumentation();
 
-        //Simulates a long running application
-        boolean longRunning = false;
-        while (longRunning) {
+        int count = 0;
+        while (count < LOOP_COUNT) {
+            count++;
             LOGGER.info("Sending a Custom Event");
             createAndAddSingleCustomEvents();
             sendEventNonBlocking();
@@ -48,27 +51,27 @@ public class MyIoTSampleApp {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+
+            LOGGER.info("Sending Network Events thru Tracker");
+            createAndAddNetworkEventsThruTracker();
+            sendEventBlocking();
+
+            LOGGER.info("Sending Network Events");
+            createAndAddNetworkEvents();
+            sendEventBlocking();
+
+            LOGGER.info("Sending Network Events w/ Correlation Headers");
+            createAndAddNetworkEventsThruTrackerWithCorrelation();
+            sendEventNonBlocking();
+
+            LOGGER.info("Sending Throwable Events");
+            createAndAddThrowable();
+            sendEventBlocking();
+
+            LOGGER.info("Sending Error Events");
+            createAndAddErrorEvent();
+            sendEventNonBlocking();
         }
-
-        LOGGER.info("Sending Network Events thru Tracker");
-        createAndAddNetworkEventsThruTracker();
-        sendEventBlocking();
-
-        LOGGER.info("Sending Network Events");
-        createAndAddNetworkEvents();
-        sendEventBlocking();
-
-        LOGGER.info("Sending Network Events w/ Correlation Headers");
-        createAndAddNetworkEventsThruTrackerWithCorrelation();
-        sendEventNonBlocking();
-
-        LOGGER.info("Sending Throwable Events");
-        createAndAddThrowable();
-        sendEventBlocking();
-
-        LOGGER.info("Sending Error Events");
-        createAndAddErrorEvent();
-        sendEventNonBlocking();
     }
 
     private static void initInstrumentation() {

--- a/sample-apps/src/main/java/com/appdynamics/iotapps/MyIoTSampleApp.java
+++ b/sample-apps/src/main/java/com/appdynamics/iotapps/MyIoTSampleApp.java
@@ -30,7 +30,7 @@ public class MyIoTSampleApp {
     public static final String APP_KEY = "<YOUR-APP-KEY>";
     public static final String COLLECTOR_URL = "<YOUR-COLLECTOR-URL>";
 
-    //Simulates a long running application
+    // Update the value of LOOP_COUNT variable to simulate long running application.
     private static final int LOOP_COUNT = 1;
 
     static final Logger LOGGER = LoggerFactory.getLogger(MyIoTSampleApp.class);


### PR DESCRIPTION
When someone clones the repo and sends the IoT traffic, it will send only network and error data and the custom event is inside a conditional loop and does not execute by default.