### PR TITLE
added support for findbugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,20 +102,17 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
     * [C++ SDK and Sample App](https://github.com/Appdynamics/iot-cpp-sdk)
     * [Python Sample Code](https://github.com/Appdynamics/iot-rest-api-sample-apps)
 
-## Miscellaneous
-* Code Coverage 
-    * `jacoco` is integrated in the `build.gradle` file to track code coverage
-    * Generate report
-    ```bash
-    cd <MY_SOURCE_FOLDER>/iot-java-sdk
-    ./gradlew test jacocoTestReport
-    ```
-    * View the report in your favorite browser
-    * For MacOS
-    ```bash
-    cd <MY_SOURCE_FOLDER>/iot-java-sdk
-    open ./sdk/build/jacocoHtml/index.html
-    ```
+## Code Inspection
+* Code Coverage
+
+    The `build.gradle` file has a task to track code coverage using `jacoco`
+
+    * Generate the report with the following gradlew command:
+        ```bash
+        cd <MY_SOURCE_FOLDER>/iot-java-sdk
+        ./gradlew test jacocoTestReport
+        ```
+    * View the report by opening the file `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/jacocoHtml/index.html` in a browser.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
     * [C++ SDK and Sample App](https://github.com/Appdynamics/iot-cpp-sdk)
     * [Python Sample Code](https://github.com/Appdynamics/iot-rest-api-sample-apps)
 
+## Miscellaneous
+* Code Quality
+    * `findbugs` is integrated in the `build.gradle` file to track code quality
+    * Generate report
+    ```bash
+        cd <MY_SOURCE_FOLDER>/iot-java-sdk
+      ./gradlew check
+    ```
+    * View the report with your favorite XML Formatter. Stylesheets can be downloaded from
+    [here](https://github.com/findbugsproject/findbugs/tree/master/findbugs/src/xsl)
+    They are not included with this project due to licensing issues
+    ```bash
+    <MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/main.xml
+    <MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/test.xml
+    <MY_SOURCE_FOLDER>/iot-java-sdk/sample-apps/build/reports/findbugs/main.xml
+    ```
 
 ## Versioning
 Versioning of releases of this project is maintained under the [Semantic Versioning Guidelines](https://semver.org/)

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
     * [Python Sample Code](https://github.com/Appdynamics/iot-rest-api-sample-apps)
 
 ## Miscellaneous
-* Test Code Coverage
-    jacoco is integrated in the build.gradle file
-    * Run jacoco to get a code coverage report from the top-level project directory.
+* Code Coverage 
+    * `jacoco` is integrated in the `build.gradle` file to track code coverage
+    * Generate report from the top-level project directory.
     ```bash
        ./gradlew test jacocoTestReport
     ```
-    * The test code coverage report can be found here
+    * View the report
     ```bash
       ./sdk//build/jacocoHtml/index.html 
     ```

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
     * For MacOS
     ```bash
     cd <MY_SOURCE_FOLDER>/iot-java-sdk
-    open ./sdk//build/jacocoHtml/index.html
+    open ./sdk/build/jacocoHtml/index.html
     ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
         ```
     * View the report by opening the file `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/jacocoHtml/index.html` in a browser.
 
+* Code Quality
+    
+    The `build.gradle` file has a task to track code quality using `findbugs`
+
+    * Generate report with the following gradlew command:
+        ```bash
+        cd <MY_SOURCE_FOLDER>/iot-java-sdk
+        ./gradlew check
+        ```
+    * View the report by opening the files
+    
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/main.xml`
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/test.xml`
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sample-apps/build/reports/findbugs/main.xml`
+    
+    * Stylesheets can be downloaded from
+    [here](https://github.com/findbugsproject/findbugs/tree/master/findbugs/src/xsl)
+   
 ## Versioning
 
 Versioning of releases of this project is maintained under the [Semantic Versioning Guidelines](https://semver.org/)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Note: If you do not have an AppDynamics account, you can sign up for one [here.]
 reported to the EUM Collector.
 
 ## Download the Released JAR 
+
 The released version of the SDK can be downloaded from https://github.com/Appdynamics/iot-java-sdk/releases.
 
 ## Build the SDK
@@ -91,7 +92,7 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
 	cd <MY_SOURCE_FOLDER>/iot-java-sdk  
 	./gradlew -p sdk/ clean assemble test generateZippedJavadocs
 	```
- 
+
 ## Documentation
 
 * [Javadoc](https://appdynamics.github.io/iot-java-sdk/) 
@@ -101,8 +102,20 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
     * [C++ SDK and Sample App](https://github.com/Appdynamics/iot-cpp-sdk)
     * [Python Sample Code](https://github.com/Appdynamics/iot-rest-api-sample-apps)
 
+## Miscellaneous
+* Test Code Coverage
+    jacoco is integrated in the build.gradle file
+    * Run jacoco to get a code coverage report from the top-level project directory.
+    ```bash
+       ./gradlew test jacocoTestReport
+    ```
+    * The test code coverage report can be found here
+    ```bash
+      ./sdk//build/jacocoHtml/index.html 
+    ```
 
 ## Versioning
+
 Versioning of releases of this project is maintained under the [Semantic Versioning Guidelines](https://semver.org/)
 
 ## Copyright and License

--- a/README.md
+++ b/README.md
@@ -105,13 +105,16 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
 ## Miscellaneous
 * Code Coverage 
     * `jacoco` is integrated in the `build.gradle` file to track code coverage
-    * Generate report from the top-level project directory.
+    * Generate report
     ```bash
-       ./gradlew test jacocoTestReport
+    cd <MY_SOURCE_FOLDER>/iot-java-sdk
+    ./gradlew test jacocoTestReport
     ```
-    * View the report
+    * View the report in your favorite browser
+    * For MacOS
     ```bash
-      ./sdk//build/jacocoHtml/index.html 
+    cd <MY_SOURCE_FOLDER>/iot-java-sdk
+    open ./sdk//build/jacocoHtml/index.html
     ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -125,14 +125,10 @@ The released version of the SDK can be downloaded from https://github.com/Appdyn
         ```
     * View the report by opening the files
     
-    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/main.xml`
-    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/test.xml`
-    `<MY_SOURCE_FOLDER>/iot-java-sdk/sample-apps/build/reports/findbugs/main.xml`
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/main.html`
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sdk/build/reports/findbugs/test.html`
+    `<MY_SOURCE_FOLDER>/iot-java-sdk/sample-apps/build/reports/findbugs/main.html`
     
-    * Stylesheets can be downloaded from
-    [here](https://github.com/findbugsproject/findbugs/tree/master/findbugs/src/xsl)
-
-
 ## Versioning
 
 Versioning of releases of this project is maintained under the [Semantic Versioning Guidelines](https://semver.org/)

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,8 @@ configure(subprojects) {
     tasks.withType(FindBugs) {
         ignoreFailures true
         reports {
-            xml.withMessages true
+            html.enabled true
+            xml.enabled false
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@
 configure(subprojects) {
     apply plugin: 'java'
     apply plugin: 'jacoco'
+    apply plugin: 'findbugs'
 
     sourceCompatibility = '1.7'
     targetCompatibility = '1.7'
@@ -37,6 +38,12 @@ configure(subprojects) {
         }
     }
 
+    tasks.withType(FindBugs) {
+        ignoreFailures true
+        reports {
+            xml.withMessages true
+        }
+    }
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,20 @@
 
 configure(subprojects) {
     apply plugin: 'java'
+    apply plugin: 'findbugs'
 
     sourceCompatibility = '1.7'
     targetCompatibility = '1.7'
 
     repositories {
         mavenCentral()
+    }
+
+    tasks.withType(FindBugs) {
+        ignoreFailures true
+        reports {
+            xml.withMessages true
+        }
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,25 @@
 
 configure(subprojects) {
     apply plugin: 'java'
+    apply plugin: 'jacoco'
 
     sourceCompatibility = '1.7'
     targetCompatibility = '1.7'
 
     repositories {
         mavenCentral()
+    }
+
+    jacoco {
+        toolVersion = "0.8.1"
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled false
+            csv.enabled false
+            html.destination file("${buildDir}/jacocoHtml")
+        }
     }
 
 }


### PR DESCRIPTION
Run command 
./gradlew check to run the report.

I did not add any of the xsl files for reading the xml reports because they are GPL licensed.
The README has instructions on where to find those xsl files. 

This PR does not fix any of the warnings reported by findbugs.

BTW, next version of findbugs is spotbugs, but findbugs has an official plugin supported by gradle so am using that. It can be upgraded when spotbugs is officially supported by gradle.



